### PR TITLE
feat: 新增SequenceExpression支持

### DIFF
--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -294,4 +294,11 @@ export default class Plugin {
     const { node } = path;
     this.buildExpressionHandler(node, ['superClass'], path, state);
   }
+
+  SequenceExpression(path, state) {
+    const { node } = path;
+
+    const expressionsProps = node.expressions.map((_, index) => index);
+    this.buildExpressionHandler(node.expressions, expressionsProps, path, state);
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -101,6 +101,7 @@ export default function ({ types }) {
     'ClassDeclaration',
     'SwitchStatement',
     'SwitchCase',
+    'SequenceExpression',
   ];
 
   const ret = {

--- a/test/fixtures/sequence-expression/actual.js
+++ b/test/fixtures/sequence-expression/actual.js
@@ -1,0 +1,5 @@
+import { Button } from 'antd';
+
+(true, Button);
+
+true ? (true, Button) : (false, Button);

--- a/test/fixtures/sequence-expression/expected.js
+++ b/test/fixtures/sequence-expression/expected.js
@@ -1,0 +1,9 @@
+"use strict";
+
+var _button = _interopRequireDefault(require("antd/lib/button"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+true, _button.default;
+
+true ? (true, _button.default) : (false, _button.default);


### PR DESCRIPTION
解决 SequenceExpression 没有被插件处理的问题

``` typescript-react
// 修复前
import { Button } from 'antd';

(true, Button);

// => 
true, Button;
```

有类似问题：#593 